### PR TITLE
Remove _pjax parameter from URL before ajax call

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -335,6 +335,9 @@
 			xhr.abort()
 		}
 
+		// Strip _pjax parameter from URL, if exists.
+		options.url=stripPjaxParam(options.url);
+
 		pjax.options = options
 		var xhr = pjax.xhr = $.ajax(options)
 


### PR DESCRIPTION
To avoid duplicates of _pjax parameter, remove it from the url before ajax call ($.ajax() will add it via its data parameter)
Related to yiisoft/yii2#2495
