### PR TITLE
Fixes #2

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -708,7 +708,7 @@
 			if (matchedScripts.length) return
 
 			var script = document.createElement('script')
-			script.type = $(this).attr('type')
+			script.type = $(this).attr('type') || 'text/javascript';
 			script.src = $(this).attr('src')
 			document.head.appendChild(script)
 		})


### PR DESCRIPTION
Add default type "text/javascript" to script without a type returned by pjax.
Should fix #2 
