### PR TITLE
Let PJAX request follows HTTP Redirect in any case

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -231,9 +231,11 @@
 
 		options.error = function (xhr, textStatus, errorThrown) {
 			var container = extractContainer("", xhr, options)
-
-			var allowed = fire('pjax:error', [xhr, textStatus, errorThrown, options])
-			if (options.type == 'GET' && textStatus !== 'abort' && allowed) {
+			// Check redirect status code
+			var redirect = (xhr.status >= 301 && xhr.status <= 303)
+			// Do not fire pjax::error in case of redirect
+			var allowed = redirect || fire('pjax:error', [xhr, textStatus, errorThrown, options])
+			if (redirect || (options.type == 'GET' && textStatus !== 'abort' && allowed)) {
 				locationReplace(container.url)
 			}
 		}
@@ -342,7 +344,7 @@
 		}
 
 		// Strip _pjax parameter from URL, if exists.
-		options.url=stripPjaxParam(options.url);
+		options.url = stripPjaxParam(options.url);
 
 		pjax.options = options
 		var xhr = pjax.xhr = $.ajax(options)


### PR DESCRIPTION
As you may see in the code, I won't fire `pjax:error` event in case of a redirect, because I think this is not useful (and a http redirect is not an error IMHO)

Question, should JS files be rewritten with spaces instead of tabs ?
