### PR TITLE
Check for duplicate secret parameter

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -194,7 +194,7 @@ function pjax(options) {
   // Without adding this secret parameter, some browsers will often
   // confuse the two.
   if (!options.data) options.data = {}
-  if ($.isArray(options.data)) {
+  if ($.isArray(options.data) && 0 === $.grep(options.data, function(obj) { return '_pjax' === obj.name }).length) {
     options.data.push({name: '_pjax', value: context.selector})
   } else {
     options.data._pjax = context.selector

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -194,7 +194,8 @@ function pjax(options) {
   // Without adding this secret parameter, some browsers will often
   // confuse the two.
   if (!options.data) options.data = {}
-  if ($.isArray(options.data) && 0 === $.grep(options.data, function(obj) { return '_pjax' === obj.name }).length) {
+  if ($.isArray(options.data)) {
+    options.data = $.grep(options.data, function(obj) { return '_pjax' !== obj.name })
     options.data.push({name: '_pjax', value: context.selector})
   } else {
     options.data._pjax = context.selector


### PR DESCRIPTION
If pjax receives data as an array you can end up with duplicate secret parameters `_pjax=#container`

Can occur with a filter on a `GridView`.