### PR TITLE
Fix cache option

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -780,7 +780,7 @@ function extractContainer(data, xhr, options) {
 //
 // Returns nothing.
 function cachePush(id, value) {
-		if(!pjax.options.cache) {
+		if(!pjax.defaults.cache) {
 			return;
 		}
   cacheMapping[id] = value
@@ -803,7 +803,7 @@ function cachePush(id, value) {
 //
 // Returns nothing.
 function cachePop(direction, id, value) {
-		if(!pjax.options.cache) {
+		if(!pjax.defaults.cache) {
 			return;
 		}
   var pushStack, popStack


### PR DESCRIPTION
One test case:

```
Page A go to Page B.
Page B loads pjax plugin.
Ctrl+r (refresh/clean cache).
Go back.

Error: pjax.options.cache is undefined
```

Pjax options are defined after a pjax request is made. Before that, pjax.defaults should be used.
[e.g.](https://github.com/yiisoft/jquery-pjax/blob/master/jquery.pjax.js#L825)