### PR TITLE
Fix document scrollTop

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -305,7 +305,9 @@ function pjax(options) {
       state: pjax.state,
       previousState: previousState
     })
+    var _scroll_top = window.document.body.scrollTop;
     context.html(container.contents)
+    window.document.body.scrollTop = _scroll_top;
 
     // FF bug: Won't autofocus fields that are inserted via JS.
     // This behavior is incorrect. So if theres no current focus, autofocus


### PR DESCRIPTION
When replacing context.html remove the old html code and the page is reduced in height after adding a new block with the new html code scroll will not mix into the original position