### PR TITLE
fix cache option not persisting after back

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -296,7 +296,8 @@ function pjax(options) {
       title: container.title,
       container: context.selector,
       fragment: options.fragment,
-      timeout: options.timeout
+      timeout: options.timeout,
+      cache: options.cache
     }
 
     if (options.history && (options.push || options.replace)) {
@@ -354,7 +355,8 @@ function pjax(options) {
       title: document.title,
       container: context.selector,
       fragment: options.fragment,
-      timeout: options.timeout
+      timeout: options.timeout,
+      cache: options.cache
     }
     window.history.replaceState(pjax.state, document.title)
   }
@@ -480,6 +482,7 @@ function onPjaxPopstate(event) {
         push: false,
         fragment: state.fragment,
         timeout: state.timeout,
+        cache: state.cache,
         scrollTo: false
       }
 

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -463,7 +463,18 @@ function onPjaxPopstate(event) {
     if (container.length) {
       var contents = cacheMapping[state.id]
 
-      if (previousState) {
+      var options = {
+        id: state.id,
+        url: state.url,
+        container: container,
+        push: false,
+        fragment: state.fragment,
+        timeout: state.timeout,
+        cache: state.cache,
+        scrollTo: false
+      }
+
+      if (previousState && options.cache) {
         // Cache current container before replacement and inform the
         // cache which direction the history shifted.
         cachePop(direction, previousState.id, cloneContents(container))
@@ -475,16 +486,6 @@ function onPjaxPopstate(event) {
       })
       container.trigger(popstateEvent)
 
-      var options = {
-        id: state.id,
-        url: state.url,
-        container: container,
-        push: false,
-        fragment: state.fragment,
-        timeout: state.timeout,
-        cache: state.cache,
-        scrollTo: false
-      }
 
       if (contents) {
         container.trigger('pjax:start', [null, options])
@@ -840,9 +841,6 @@ function cachePush(id, value) {
 //
 // Returns nothing.
 function cachePop(direction, id, value) {
-  if(!pjax.options.cache) {
-    return;
-  }
   var pushStack, popStack
   cacheMapping[id] = value
 


### PR DESCRIPTION
If you click around on a pjaxed page, then go back, the cache option is reset to true for that page view (i.e. if you then go forward or back, pjax will not reload the page from the server, it will use the cache).
