### PR TITLE
It makes it possible to append scripts synchronously

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -314,6 +314,7 @@ function pjax(options) {
       state: pjax.state,
       previousState: previousState
     })
+    executeScriptTags(container.scripts)
     context.html(container.contents)
 
     // FF bug: Won't autofocus fields that are inserted via JS.
@@ -325,8 +326,6 @@ function pjax(options) {
     if (autofocusEl && document.activeElement !== autofocusEl) {
       autofocusEl.focus();
     }
-
-    executeScriptTags(container.scripts)
 
     var scrollTo = options.scrollTo
 
@@ -796,7 +795,12 @@ function executeScriptTags(scripts) {
     var type = $(this).attr('type')
     if (type) script.type = type
     script.src = $(this).attr('src')
-    document.head.appendChild(script)
+    if (pjax.options.async) {
+    	document.head.appendChild(script)
+    }
+    else {
+    	$(document.body).append(script)
+    }
   })
 }
 


### PR DESCRIPTION
Sometimes it is necessary to add scripts dynamically. If you enable async option (true) pjax will operate as usual. If false, scripts to load synchronously.
Why do it? Scripts are loaded on the fly, and client scripts waiting until all the necessary scripts to connect to and then work out fine.