### PR TITLE
Only blur the focused element if it is inside Pjax container

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -303,10 +303,15 @@ function pjax(options) {
       window.history.replaceState(pjax.state, container.title, container.url)
     }
 
+    // Only blur the focus if the focused element is within the container.
+    var blurFocus = $.contains(options.container, document.activeElement)
+
     // Clear out any focused controls before inserting new page contents.
-    try {
-      document.activeElement.blur()
-    } catch (e) { }
+    if (blurFocus) {
+      try {
+        document.activeElement.blur()
+      } catch (e) { }
+    }
 
     if (container.title) document.title = container.title
 


### PR DESCRIPTION
Fix for an issue that has come up on the forums a few times. If you're using Pjax to refresh some results (eg. live search) then element focus is lost.

https://github.com/yiisoft/yii2/issues/4677