### PR TITLE
Added `skipOuterContainers` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 yii-pjax Change Log
 ===================
 
+2.0.6 Under development
+-----------------
+- New: Added `skipOuter` option (silverfire)
+
 2.0.3 Mar 7, 2015
 -----------------
 - Chg: Merged changes from upstream (samdark)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ key | default | description
 `url` | link.href | a string or function that returns the URL for the ajax request
 `target` | link | eventually the `relatedTarget` value for [pjax events](#events)
 `fragment` | | CSS selector for the fragment to extract from ajax response
+`skipOuter` | false | When pjax containters are nested and this option is true, the closest pjax block will handle the event. Otherwise, the top container will handle the event
 
 You can change the defaults globally by writing to the `$.pjax.defaults` object:
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ key | default | description
 `url` | link.href | a string or function that returns the URL for the ajax request
 `target` | link | eventually the `relatedTarget` value for [pjax events](#events)
 `fragment` | | CSS selector for the fragment to extract from ajax response
-`skipOuter` | false | When pjax containters are nested and this option is true, the closest pjax block will handle the event. Otherwise, the top container will handle the event
+`skipOuterContainers` | false | When pjax containers are nested and this option is true, the closest pjax block will handle the event. Otherwise, the top container will handle the event
 
 You can change the defaults globally by writing to the `$.pjax.defaults` object:
 

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -28,6 +28,9 @@
 //           cache - Whether to cache pages HTML. Defaults to true
 //    pushRedirect - Whether to pushState the URL for redirects. Defaults to false.
 // replaceRedirect - Whether to replaceState the URL for redirects. Defaults to true.
+//       skipOuter - When pjax containters are nested and this option is true,
+//                   the closest pjax block will handle the event. Otherwise, the top
+//                   container will handle the event. Defaults to false.
 //
 // For convenience the second parameter can be either the container or
 // the options object.
@@ -366,6 +369,10 @@ function pjax(options) {
     window.history.replaceState(pjax.state, document.title)
   }
 
+  // New request can not override the existing one when option skipOuter is set to true
+  if (pjax.xhr && pjax.xhr.readyState < 4 && pjax.options.skipOuter) {
+    return
+  }
   // Cancel the current request if we're already pjaxing
   abortXHR(pjax.xhr)
 
@@ -918,6 +925,7 @@ function enable() {
     version: findVersion,
     pushRedirect: false,
     replaceRedirect: true
+    skipOuter: false,
   }
   $(window).on('popstate.pjax', onPjaxPopstate)
 }

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -19,18 +19,18 @@
 // pjax specific options:
 //
 //
-//       container - Where to stick the response body. Usually a String selector.
-//                   $(container).html(xhr.responseBody)
-//                   (default: current jquery context)
-//            push - Whether to pushState the URL. Defaults to true (of course).
-//         replace - Want to use replaceState instead? That's cool.
-//         history - Work with window.history. Defaults to true
-//           cache - Whether to cache pages HTML. Defaults to true
-//    pushRedirect - Whether to pushState the URL for redirects. Defaults to false.
-// replaceRedirect - Whether to replaceState the URL for redirects. Defaults to true.
-//       skipOuter - When pjax containters are nested and this option is true,
-//                   the closest pjax block will handle the event. Otherwise, the top
-//                   container will handle the event. Defaults to false.
+//           container - Where to stick the response body. Usually a String selector.
+//                       $(container).html(xhr.responseBody)
+//                       (default: current jquery context)
+//                push - Whether to pushState the URL. Defaults to true (of course).
+//             replace - Want to use replaceState instead? That's cool.
+//             history - Work with window.history. Defaults to true
+//               cache - Whether to cache pages HTML. Defaults to true
+//        pushRedirect - Whether to pushState the URL for redirects. Defaults to false.
+//     replaceRedirect - Whether to replaceState the URL for redirects. Defaults to true.
+// skipOuterContainers - When pjax containers are nested and this option is true,
+//                       the closest pjax block will handle the event. Otherwise, the top
+//                       container will handle the event. Defaults to false.
 //
 // For convenience the second parameter can be either the container or
 // the options object.
@@ -369,8 +369,8 @@ function pjax(options) {
     window.history.replaceState(pjax.state, document.title)
   }
 
-  // New request can not override the existing one when option skipOuter is set to true
-  if (pjax.xhr && pjax.xhr.readyState < 4 && pjax.options.skipOuter) {
+  // New request can not override the existing one when option skipOuterContainers is set to true
+  if (pjax.xhr && pjax.xhr.readyState < 4 && pjax.options.skipOuterContainers) {
     return
   }
   // Cancel the current request if we're already pjaxing
@@ -924,8 +924,8 @@ function enable() {
     maxCacheLength: 20,
     version: findVersion,
     pushRedirect: false,
-    replaceRedirect: true
-    skipOuter: false,
+    replaceRedirect: true,
+    skipOuterContainers: false
   }
   $(window).on('popstate.pjax', onPjaxPopstate)
 }


### PR DESCRIPTION
This PR adds `skipOuter` option.

The use case:

```html
<div class="container" id="pjax-container">
    Go to <a href="/page/2">next page</a>.
    <div class="status-container" id="pjax-status-container">
        <span>Last check found no errors on page 1</span>
        <a href="/update-status/page/1">Check again</a>
    </div>
</div>
<script>
    $(document).pjax('a', '#pjax-container');
    $(document).pjax('a', '#pjax-status-container', {
        push: false,
        replace: false,
        timeout: 0
    })
</script>
```

I want to use a link inside `div#pjax-container` to navigate between pages with pushing URLs to the history. Every page displays some info and has a button `Check again` to update that info without page refresh or pushing to the browser history. As you see, I placed the button inside new container and defined a special config for it.

Without out this PR, the config of `#pjax-status-container` is useless, because the network request of `#pjax-status-container` will be immediately aborted by `#pjax-container`. Then `#pjax-container` will create his own request and process it according to it's rules.

When `skipOuter = true` only the closest container will handle the request.

The options defaults to false, so it doesn't break BC.