### PR TITLE
Add `scrollOffset` option and update `scrollTop` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,7 @@ key | default | description
 `replace` | false | replace URL without adding browser history entry
 `maxCacheLength` | 20 | maximum cache size for previous container contents
 `version` | | a string or function returning the current pjax version
-`scrollTo` | 0 | vertical position to scroll to after navigation. To avoid changing scroll position, pass `false`. If set to `true` page will scroll to the pjax container. 
-Can also be be a callback function with context and current hash passed in as parameters. E.g. `function (context, hash) { if (!hash) return $(context).offset().top; }`
+`scrollTo` | 0 | vertical position to scroll to after navigation. To avoid changing scroll position, pass `false`. If set to `true` page will scroll to the pjax container. Can also be be a callback function with context and current hash passed in as parameters. E.g. `function (context, hash) { if (!hash) return $(context).offset().top; }`
 `scrollOffset` | 0 | vertical offset that gets added to `scrollTo`. Can be a callback function with the current `scrollTo` value passed as a parameter.
 `type` | `"GET"` | see [$.ajax][]
 `dataType` | `"html"` | see [$.ajax][]

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ key | default | description
 `replace` | false | replace URL without adding browser history entry
 `maxCacheLength` | 20 | maximum cache size for previous container contents
 `version` | | a string or function returning the current pjax version
-`scrollTo` | 0 | vertical position to scroll to after navigation. To avoid changing scroll position, pass `false`.
+`scrollTo` | 0 | vertical position to scroll to after navigation. To avoid changing scroll position, pass `false`. If set to `true` page will scroll to the pjax container. 
+Can also be be a callback function with context and current hash passed in as parameters. E.g. `function (context, hash) { if (!hash) return $(context).offset().top; }`
+`scrollOffset` | 0 | vertical offset that gets added to `scrollTo`. Can be a callback function with the current `scrollTo` value passed as a parameter.
 `type` | `"GET"` | see [$.ajax][]
 `dataType` | `"html"` | see [$.ajax][]
 `container` | | CSS selector for the element where content should be replaced

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -355,16 +355,29 @@ function pjax(options) {
 
     executeScriptTags(container.scripts, context)
 
-    var scrollTo = options.scrollTo
-
-    // Ensure browser scrolls to the element referenced by the URL anchor
-    if (hash) {
-      var name = decodeURIComponent(hash.slice(1))
-      var target = document.getElementById(name) || document.getElementsByName(name)[0]
-      if (target) scrollTo = $(target).offset().top
+    
+    if (typeof options.scrollTo === 'function') {
+        var scrollTo = options.scrollTo(context, hash)
+    } else {
+        var scrollTo = options.scrollTo
+        // Ensure browser scrolls to the element referenced by the URL anchor
+        if (hash || true === scrollTo) {
+          var name = decodeURIComponent(hash.slice(1))
+          var target = true === scrollTo ? context : (document.getElementById(name) || document.getElementsByName(name)[0])
+          if (target) scrollTo = $(target).offset().top
+        }
     }
 
-    if (typeof scrollTo == 'number') $(window).scrollTop(scrollTo)
+    if (typeof options.scrollOffset === 'function')
+        var scrollOffset = options.scrollOffset(scrollTo)
+    else 
+        var scrollOffset = options.scrollOffset
+    
+    if (typeof scrollTo === 'number') {
+        scrollTo = scrollTo + scrollOffset;
+        if (scrollTo < 0) scrollTo = 0
+        $(window).scrollTop(scrollTo)
+    }
 
     fire('pjax:success', [data, status, xhr, options])
   }


### PR DESCRIPTION


Includes changes from #42.

 - Updated `scrollTo` option to accept a function callback with parameters context and hash.
 - Updated `scrollTo` option if set to true page will scroll to pjax container.
 - Added `scrollOffset` option to offset the `scrollTo` position if needed. `scrollOffset` can be a callback function with the current `scrollTo` value passed as a parameter.