### PR TITLE
Restore the last semicolon for Yii asset/compress

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -1015,4 +1015,4 @@ if ($.support.pjax) {
   disable()
 }
 
-})(jQuery)
+})(jQuery);


### PR DESCRIPTION
Yii's `asset/compress` command cannot join JavaScripts they doesn't have semicolon at  EOF correctly. 

https://github.com/yiisoft/yii2/blob/1501c659aca7c50fa5e4f6fbe5ca549acc946c86/framework/console/controllers/AssetController.php#L571

So, I got these probrem with yii2-pjax 2.0.7:

<img width="457" alt="no-semicolon" src="https://user-images.githubusercontent.com/403893/31226580-95edbb6c-aa11-11e7-93bd-d1b34c0f2be6.png">

```js
)(jQuery)
/*** END FILE: jquery.pjax.js ***/
/*** BEGIN FILE: yii.activeForm.js ***/
(function($){
```

Above would be compressed as:

```js
)(jQuery)(function($){
```

I expect:

```js
)(jQuery);(function($){
```
