### PR TITLE
Fixing of wrong events lifecycle in case when ajax request is not async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,10 @@
 yii-pjax Change Log
 ===================
 
-2.0.9 Nov 8, 2022
------------------
-
-- Bug #71: Wrong events lifecycle in case when ajax request is not async (iovzt)
-
 2.0.8 under development
 -----------------------
 
-- no changes in this release.
+- Bug #71: Wrong events lifecycle in case when ajax request is not async (iovzt)
 
 
 v2.0.7.1 Oct 12, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 yii-pjax Change Log
 ===================
 
+2.0.9 Nov 8, 2022
+-----------------
+
+- Bug #71: Wrong events lifecycle in case when ajax request is not async (iovzt)
+
 2.0.8 under development
 -----------------------
 

--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -260,6 +260,11 @@ function pjax(options) {
     var url = parseURL(settings.url)
     if (hash) url.hash = hash
     options.requestUrl = stripInternalParams(url)
+
+    if (typeof (options.async) !== 'undefined' && !options.async) {
+      fire('pjax:start', [xhr, options])
+      fire('pjax:send', [xhr, options])
+    }
   }
 
   options.complete = function(xhr, textStatus) {
@@ -427,8 +432,10 @@ function pjax(options) {
       window.history.pushState(null, "", options.requestUrl)
     }
 
-    fire('pjax:start', [xhr, options])
-    fire('pjax:send', [xhr, options])
+    if (typeof (options.async) === 'undefined' || options.async) {
+      fire('pjax:start', [xhr, options])
+      fire('pjax:send', [xhr, options])
+    }
   }
 
   return pjax.xhr


### PR DESCRIPTION
Fix for case when we use container reloading with synchronous ajax request

`$.pjax.reload({container: '#pjax-container', async: false});`

and events fire in unexpected order:

pjax:beforeSend
pjax:beforeReplace
pjax:success
pjax:complete
pjax:end
pjax:start
pjax:send