### PR TITLE
gemfilelock-updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ yii-pjax Change Log
 2.0.9 under development
 -----------------------
 
-- No changes in this release yet.
+- Update dependencies for Sinatra and Rack
 
 2.0.8 Nov 9, 2022
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ yii-pjax Change Log
 2.0.9 under development
 -----------------------
 
-- Update dependencies for Sinatra and Rack
+- Chg #73: Update dependencies for Sinatra and Rack (craiglondon)
 
 2.0.8 Nov 9, 2022
 -----------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (1.5.2)
-    rack-protection (1.5.3)
-      rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    base64 (0.2.0)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.13)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    ruby2_keywords (0.0.5)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
+      tilt (~> 2.0)
+    tilt (2.6.0)
 
 PLATFORMS
   ruby
@@ -17,4 +23,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.14.6
+   1.17.2


### PR DESCRIPTION
sinatra@1.4.5 was using rack@1.5.2 which has vulnerabilities (DoS, arbitrary code execution, path traversal)